### PR TITLE
fix: absolute path gone wrong

### DIFF
--- a/src/components/NewTaskForm.css
+++ b/src/components/NewTaskForm.css
@@ -13,7 +13,16 @@ form.new-task {
 form.new-task > div {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: start;
+  margin: 10px;
+}
+
+form.new-task > div > input[type="text"] {
+  font-size: 15px;
+  width: 100%;
+  font-weight: bolder;
+  border: 2px solid black;
+  padding: 15px;
 }
 
 form.new-task > div > input {

--- a/src/components/NewTaskForm.jsx
+++ b/src/components/NewTaskForm.jsx
@@ -57,9 +57,9 @@ export function NewTaskForm() {
         X
       </Link>
       <div>
-        <label htmlFor="title">Title</label>
         <input
           type="text"
+          placeholder="Title"
           id="title"
           value={newTask.title}
           onChange={(e) => {
@@ -69,10 +69,10 @@ export function NewTaskForm() {
         />
       </div>
       <div>
-        <label htmlFor="description">Description</label>
         <input
           type="text"
           id="description"
+          placeholder="Description"
           value={newTask.description}
           onChange={(e) => {
             setSubmitting(false);
@@ -81,7 +81,7 @@ export function NewTaskForm() {
         />
       </div>
       <div className="finished-input-section">
-        <label htmlFor="finished">Finished</label>
+        <label htmlFor="finished">Finished...?</label>
         <input
           type="checkbox"
           id="finished"

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,7 +10,7 @@ import { createUrl } from "./utils/linkHelpers.js";
 
 const router = createBrowserRouter([
   {
-    path: createUrl(),
+    path: createUrl("/"),
     element: <App />,
     children: [
       {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,7 +10,7 @@ import { createUrl } from "./utils/linkHelpers.js";
 
 const router = createBrowserRouter([
   {
-    path: createUrl("/"),
+    path: createUrl(),
     element: <App />,
     children: [
       {

--- a/src/utils/linkHelpers.js
+++ b/src/utils/linkHelpers.js
@@ -1,5 +1,5 @@
 const BASE_URL = '/tasks-management';
 
-export const createUrl = (path) => {
+export const createUrl = (path = "/") => {
   return `${BASE_URL}${path}`;
 };


### PR DESCRIPTION
Uncaught Error: Absolute route path "/tasks-management/create" nested under path "/tasks-managementundefined" is not valid. An absolute child route path must start with the combined path of all its parent routes.